### PR TITLE
Show the Minecraft server name when it's started

### DIFF
--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -50,7 +50,8 @@ async function startMinecraft (logger, message) {
 
     switch (serverStatus) {
       case 'Running':
-        message.reply(`Minecraft is ready! Connect to ${serverStatus}`)
+        const serverName = serverData.serverName
+        message.reply(`Minecraft is ready!${serverName && ` Connect to ${serverName}`}`)
         return
 
       case 'Stopping':


### PR DESCRIPTION
Show the server name instead of suggesting people connect to the server status (e.g. `Connect to minecraft.net` instead of `Connect to Started`).

While we're at it, also don't show the `Connect to` part unless we actually got back a server name.